### PR TITLE
chore(mksquashfs): compile with zstd

### DIFF
--- a/Dockerfile.squashfs-tools
+++ b/Dockerfile.squashfs-tools
@@ -22,11 +22,11 @@ RUN git clone https://github.com/plougher/squashfs-tools && cd squashfs-tools &&
 WORKDIR /usr/src/squashfs-tools/squashfs-tools
 # We don't use most of these libs, so turn them off.
 RUN sed -i \
-  -e 's/LZO_SUPPORT = 1/LZO_SUPPORT = 0/' \
-  -e 's/XZ_SUPPORT = 1/XZ_SUPPORT = 0/' \
-  -e 's/LZ4_SUPPORT = 1/LZ4_SUPPORT = 0/' \
-  -e 's/USE_PREBUILT_MANPAGES = n/USE_PREBUILT_MANPAGES = y/' \
-  Makefile
+    -e 's/LZO_SUPPORT = 1/LZO_SUPPORT = 0/' \
+    -e 's/XZ_SUPPORT = 1/XZ_SUPPORT = 0/' \
+    -e 's/LZ4_SUPPORT = 1/LZ4_SUPPORT = 0/' \
+    -e 's/USE_PREBUILT_MANPAGES = n/USE_PREBUILT_MANPAGES = y/' \
+    Makefile
 ENV CFLAGS="-O2 -Wall -static"
 ENV LDFLAGS="-static"
 

--- a/Dockerfile.squashfs-tools
+++ b/Dockerfile.squashfs-tools
@@ -6,7 +6,7 @@ ARG SQUASHFS_TOOLS_VERSION=65362f488c8859db6612a1ed3630c7352fff2a7e
 WORKDIR /usr/src
 
 # build dependencies
-RUN apk update && apk add build-base cmake git sed
+RUN apk update && apk add build-base cmake git sed zstd-dev zstd-static
 # build zlib-ng in static lib/"zlib-compat" mode (alpine doesn't have a static/dev variant yet)
 ENV ZLIB_NG_VERSION=2.2.4
 RUN git clone https://github.com/zlib-ng/zlib-ng.git && cd zlib-ng && git checkout $ZLIB_NG_VERSION
@@ -22,12 +22,11 @@ RUN git clone https://github.com/plougher/squashfs-tools && cd squashfs-tools &&
 WORKDIR /usr/src/squashfs-tools/squashfs-tools
 # We don't use most of these libs, so turn them off.
 RUN sed -i \
-    -e 's/LZO_SUPPORT = 1/LZO_SUPPORT = 0/' \
-    -e 's/XZ_SUPPORT = 1/XZ_SUPPORT = 0/' \
-    -e 's/ZSTD_SUPPORT = 1/ZSTD_SUPPORT = 0/' \
-    -e 's/LZ4_SUPPORT = 1/LZ4_SUPPORT = 0/' \
-    -e 's/USE_PREBUILT_MANPAGES = n/USE_PREBUILT_MANPAGES = y/' \
-    Makefile
+  -e 's/LZO_SUPPORT = 1/LZO_SUPPORT = 0/' \
+  -e 's/XZ_SUPPORT = 1/XZ_SUPPORT = 0/' \
+  -e 's/LZ4_SUPPORT = 1/LZ4_SUPPORT = 0/' \
+  -e 's/USE_PREBUILT_MANPAGES = n/USE_PREBUILT_MANPAGES = y/' \
+  Makefile
 ENV CFLAGS="-O2 -Wall -static"
 ENV LDFLAGS="-static"
 


### PR DESCRIPTION
`zstd` compression is required in some cases but wasn't built into `mksquashfs`.